### PR TITLE
each() deprecated in php 7.2

### DIFF
--- a/smd_tags.php
+++ b/smd_tags.php
@@ -4372,7 +4372,7 @@ function smd_tag_list($atts = array(), $thing = null)
         $totals = array();
         $outsub = array();
 
-        while (list($key, $row) = each($rs)) {
+        foreach ($rs as $key => $row) {
             // Only add the row if one of:
             // 1) showall is on
             // 2) sublevel = 'all'


### PR DESCRIPTION
Fix for https://github.com/Bloke/smd_tags/issues/1 replacing `while … each()` with `foreach`.